### PR TITLE
Add report for jabjab.de

### DIFF
--- a/reports/jabjab.de.txt
+++ b/reports/jabjab.de.txt
@@ -1,0 +1,55 @@
+Use compliance suite 'Advanced Server Core Compliance Suite' to test jabjab.de
+
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+passed 2/2
+
+Advanced Server Core Compliance Suite: PASSED
+
+
+Use compliance suite 'Advanced Server IM Compliance Suite' to test jabjab.de
+
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running Roster Versioning…		PASSED
+running XEP-0280: Message Carbons…		PASSED
+running XEP-0191: Blocking Command…		PASSED
+running XEP-0045: Multi-User Chat…		PASSED
+running XEP-0198: Stream Management…		PASSED
+running XEP-0313: Message Archive Management…		PASSED
+passed 8/8
+
+Advanced Server IM Compliance Suite: PASSED
+
+
+Use compliance suite 'Advanced Server Mobile Compliance Suite' to test jabjab.de
+
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running XEP-0198: Stream Management…		PASSED
+running XEP-0352: Client State Indication…		FAILED
+running XEP-0357: Push Notifications…		FAILED
+passed 3/5
+
+Advanced Server Mobile Compliance Suite: FAILED
+
+
+Use compliance suite 'Conversations Compliance Suite' to test jabjab.de
+
+Server is ejabberd 16.03
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running Roster Versioning…		PASSED
+running XEP-0280: Message Carbons…		PASSED
+running XEP-0191: Blocking Command…		PASSED
+running XEP-0045: Multi-User Chat…		PASSED
+running XEP-0198: Stream Management…		PASSED
+running XEP-0313: Message Archive Management…		PASSED
+running XEP-0352: Client State Indication…		FAILED
+running XEP-0363: HTTP File Upload…		FAILED
+running XEP-0065: SOCKS5 Bytestreams (Proxy)…		PASSED
+running XEP-0357: Push Notifications…		FAILED
+passed 9/12
+
+Conversations Compliance Suite: FAILED
+


### PR DESCRIPTION
jabjab.de has several aliases: planetjabber.de, jabberwiki.de, jabberforum.de, ybgood.de, lethyro.net, pad7.de, pad7.net