### PR TITLE
Fix the spaces/tab problem in jabber-br.org report

### DIFF
--- a/reports/jabber-br.org.txt
+++ b/reports/jabber-br.org.txt
@@ -1,7 +1,7 @@
 Use compliance suite 'Advanced Server Core Compliance Suite' to test jabber-br.org
 
-running XEP-0115: Entity Capabilities…          PASSED
-running XEP-0163: Personal Eventing Protocol…           PASSED
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
 passed 2/2
 
 Advanced Server Core Compliance Suite: PASSED
@@ -9,14 +9,14 @@ Advanced Server Core Compliance Suite: PASSED
 
 Use compliance suite 'Advanced Server IM Compliance Suite' to test jabber-br.org
 
-running XEP-0115: Entity Capabilities…          PASSED
-running XEP-0163: Personal Eventing Protocol…           PASSED
-running Roster Versioning…              PASSED
-running XEP-0280: Message Carbons…              FAILED
-running XEP-0191: Blocking Command…             FAILED
-running XEP-0045: Multi-User Chat…              PASSED
-running XEP-0198: Stream Management…            FAILED
-running XEP-0313: Message Archive Management…           FAILED
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running Roster Versioning…		PASSED
+running XEP-0280: Message Carbons…		FAILED
+running XEP-0191: Blocking Command…		FAILED
+running XEP-0045: Multi-User Chat…		PASSED
+running XEP-0198: Stream Management…		FAILED
+running XEP-0313: Message Archive Management…		FAILED
 passed 4/8
 
 Advanced Server IM Compliance Suite: FAILED
@@ -24,11 +24,11 @@ Advanced Server IM Compliance Suite: FAILED
 
 Use compliance suite 'Advanced Server Mobile Compliance Suite' to test jabber-br.org
 
-running XEP-0115: Entity Capabilities…          PASSED
-running XEP-0163: Personal Eventing Protocol…           PASSED
-running XEP-0198: Stream Management…            FAILED
-running XEP-0352: Client State Indication…              FAILED
-running XEP-0357: Push Notifications…           FAILED
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running XEP-0198: Stream Management…		FAILED
+running XEP-0352: Client State Indication…		FAILED
+running XEP-0357: Push Notifications…		FAILED
 passed 2/5
 
 Advanced Server Mobile Compliance Suite: FAILED
@@ -37,19 +37,20 @@ Advanced Server Mobile Compliance Suite: FAILED
 Use compliance suite 'Conversations Compliance Suite' to test jabber-br.org
 
 Server is Prosody 0.8.2
-running XEP-0115: Entity Capabilities…          PASSED
-running XEP-0163: Personal Eventing Protocol…           PASSED
-running Roster Versioning…              PASSED
-running XEP-0280: Message Carbons…              FAILED
-running XEP-0191: Blocking Command…             FAILED
-running XEP-0045: Multi-User Chat…              PASSED
-running XEP-0198: Stream Management…            FAILED
-running XEP-0313: Message Archive Management…           FAILED
-running XEP-0352: Client State Indication…              FAILED
-running XEP-0363: HTTP File Upload…             FAILED
-running XEP-0065: SOCKS5 Bytestreams (Proxy)…           FAILED
-running XEP-0357: Push Notifications…           FAILED
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running Roster Versioning…		PASSED
+running XEP-0280: Message Carbons…		FAILED
+running XEP-0191: Blocking Command…		FAILED
+running XEP-0045: Multi-User Chat…		PASSED
+running XEP-0198: Stream Management…		FAILED
+running XEP-0313: Message Archive Management…		FAILED
+running XEP-0352: Client State Indication…		FAILED
+running XEP-0363: HTTP File Upload…		FAILED
+running XEP-0065: SOCKS5 Bytestreams (Proxy)…		FAILED
+running XEP-0357: Push Notifications…		FAILED
 passed 4/12
 
 Conversations Compliance Suite: FAILED
+
 


### PR DESCRIPTION
ComplianceTester output uses 2 tabs to separate the XEP tests and its respective results. In past I just copied/pasted the outputs to the repository, because it that separation was using spaces instead tabs.

Now I am fixing it to jabber-br.org report.
