### PR TITLE
Renamed deshalbfrei.org.txt to draugr.de.txt and updated report

### DIFF
--- a/reports/draugr.de.txt
+++ b/reports/draugr.de.txt
@@ -1,4 +1,4 @@
-Use compliance suite 'Advanced Server Core Compliance Suite' to test deshalbfrei.org
+Use compliance suite 'Advanced Server Core Compliance Suite' to test draugr.de
 
 running XEP-0115: Entity Capabilities…		PASSED
 running XEP-0163: Personal Eventing Protocol…		PASSED
@@ -7,7 +7,7 @@ passed 2/2
 Advanced Server Core Compliance Suite: PASSED
 
 
-Use compliance suite 'Advanced Server IM Compliance Suite' to test deshalbfrei.org
+Use compliance suite 'Advanced Server IM Compliance Suite' to test draugr.de
 
 running XEP-0115: Entity Capabilities…		PASSED
 running XEP-0163: Personal Eventing Protocol…		PASSED
@@ -16,13 +16,13 @@ running XEP-0280: Message Carbons…		PASSED
 running XEP-0191: Blocking Command…		PASSED
 running XEP-0045: Multi-User Chat…		PASSED
 running XEP-0198: Stream Management…		PASSED
-running XEP-0313: Message Archive Management…		FAILED
-passed 7/8
+running XEP-0313: Message Archive Management…		PASSED
+passed 8/8
 
-Advanced Server IM Compliance Suite: FAILED
+Advanced Server IM Compliance Suite: PASSED
 
 
-Use compliance suite 'Advanced Server Mobile Compliance Suite' to test deshalbfrei.org
+Use compliance suite 'Advanced Server Mobile Compliance Suite' to test draugr.de
 
 running XEP-0115: Entity Capabilities…		PASSED
 running XEP-0163: Personal Eventing Protocol…		PASSED
@@ -34,9 +34,9 @@ passed 4/5
 Advanced Server Mobile Compliance Suite: FAILED
 
 
-Use compliance suite 'Conversations Compliance Suite' to test deshalbfrei.org
+Use compliance suite 'Conversations Compliance Suite' to test draugr.de
 
-Server is ejabberd 16.08
+Server is ejabberd 16.09
 running XEP-0115: Entity Capabilities…		PASSED
 running XEP-0163: Personal Eventing Protocol…		PASSED
 running Roster Versioning…		PASSED
@@ -44,12 +44,12 @@ running XEP-0280: Message Carbons…		PASSED
 running XEP-0191: Blocking Command…		PASSED
 running XEP-0045: Multi-User Chat…		PASSED
 running XEP-0198: Stream Management…		PASSED
-running XEP-0313: Message Archive Management…		FAILED
+running XEP-0313: Message Archive Management…		PASSED
 running XEP-0352: Client State Indication…		PASSED
-running XEP-0363: HTTP File Upload…		FAILED
+running XEP-0363: HTTP File Upload…		PASSED
 running XEP-0065: SOCKS5 Bytestreams (Proxy)…		PASSED
 running XEP-0357: Push Notifications…		FAILED
-passed 9/12
+passed 11/12
 
 Conversations Compliance Suite: FAILED
 


### PR DESCRIPTION
Deshalbfrei.org is on the same server as Draugr.de and Draugr.de is the
main domain, so the report can be moved to draugr.de.txt.