### PR TITLE
Rerun test with current ComplianceTester version

### DIFF
--- a/reports/dukgo.com.txt
+++ b/reports/dukgo.com.txt
@@ -36,7 +36,7 @@ Advanced Server Mobile Compliance Suite: FAILED
 
 Use compliance suite 'Conversations Compliance Suite' to test dukgo.com
 
-Server is Prosody 0.9 nightly build 249 (2015-11-17, f755e0bdc60a)
+Server is Prosody 0.9 nightly build 271 (2016-11-04, 003ee2be2635)
 running XEP-0115: Entity Capabilities…		PASSED
 running XEP-0163: Personal Eventing Protocol…		PASSED
 running Roster Versioning…		PASSED

--- a/reports/mailbox.org.txt
+++ b/reports/mailbox.org.txt
@@ -48,7 +48,7 @@ running XEP-0313: Message Archive Management…		PASSED
 running XEP-0352: Client State Indication…		PASSED
 running XEP-0363: HTTP File Upload…		PASSED
 running XEP-0065: SOCKS5 Bytestreams (Proxy)…		PASSED
-running XEP-0357: Push Notifications (on server)…		PASSED
+running XEP-0357: Push Notifications…		PASSED
 passed 12/12
 
 Conversations Compliance Suite: PASSED

--- a/reports/openmailbox.org.txt
+++ b/reports/openmailbox.org.txt
@@ -48,7 +48,7 @@ running XEP-0313: Message Archive Management…		FAILED
 running XEP-0352: Client State Indication…		FAILED
 running XEP-0363: HTTP File Upload…		FAILED
 running XEP-0065: SOCKS5 Bytestreams (Proxy)…		FAILED
-running XEP-0357: Push Notifications (on server)…		FAILED
+running XEP-0357: Push Notifications…		FAILED
 passed 4/12
 
 Conversations Compliance Suite: FAILED


### PR DESCRIPTION
(for dukgo.com, mailbox.org, openmailbox.org)

This should color these grey table cells.