### PR TITLE
Add report for Slack's XMPP bridge

### DIFF
--- a/reports/xmpp.slack.com.txt
+++ b/reports/xmpp.slack.com.txt
@@ -1,0 +1,56 @@
+Use compliance suite 'Advanced Server Core Compliance Suite' to test xmpp.slack.com
+
+running XEP-0115: Entity Capabilities…		FAILED
+running XEP-0163: Personal Eventing Protocol…		FAILED
+passed 0/2
+
+Advanced Server Core Compliance Suite: FAILED
+
+
+Use compliance suite 'Advanced Server IM Compliance Suite' to test xmpp.slack.com
+
+running XEP-0115: Entity Capabilities…		FAILED
+running XEP-0163: Personal Eventing Protocol…		FAILED
+running Roster Versioning…		FAILED
+running XEP-0280: Message Carbons…		FAILED
+running XEP-0191: Blocking Command…		FAILED
+running XEP-0045: Multi-User Chat…		PASSED
+running XEP-0198: Stream Management…		FAILED
+running XEP-0313: Message Archive Management…		FAILED
+passed 1/8
+
+Advanced Server IM Compliance Suite: FAILED
+
+
+Use compliance suite 'Advanced Server Mobile Compliance Suite' to test xmpp.slack.com
+
+running XEP-0115: Entity Capabilities…		FAILED
+running XEP-0163: Personal Eventing Protocol…		FAILED
+running XEP-0198: Stream Management…		FAILED
+running XEP-0352: Client State Indication…		FAILED
+running XEP-0357: Push Notifications…		FAILED
+passed 0/5
+
+Advanced Server Mobile Compliance Suite: FAILED
+
+
+Use compliance suite 'Conversations Compliance Suite' to test xmpp.slack.com
+
+Server is Slack 2.0
+running XEP-0115: Entity Capabilities…		FAILED
+running XEP-0163: Personal Eventing Protocol…		FAILED
+running Roster Versioning…		FAILED
+running XEP-0280: Message Carbons…		FAILED
+running XEP-0191: Blocking Command…		FAILED
+running XEP-0045: Multi-User Chat…		PASSED
+running XEP-0198: Stream Management…		FAILED
+running XEP-0313: Message Archive Management…		FAILED
+running XEP-0352: Client State Indication…		FAILED
+running XEP-0363: HTTP File Upload…		FAILED
+running XEP-0065: SOCKS5 Bytestreams (Proxy)…		FAILED
+running XEP-0357: Push Notifications…		FAILED
+passed 1/12
+
+Conversations Compliance Suite: FAILED
+
+


### PR DESCRIPTION
Slack provides a XMPP bridge as a kind of freedom-respecting
altiernative to their proprietary Google-Play-only app but it is not
very usable as you can see here.

It does not federate with normal XMPP servers, but I think it still
could make sense to include this report so that people who want to start
using Slack are warned – and maybe use a normal XMPP server instead. ;)

Normally you connect to a subdomain of 'xmpp.slack.com' but I removed it
because this report should be the same on every subdomain of it.