### PR TITLE
Updated report for draugr.de

### DIFF
--- a/reports/deshalbfrei.org.txt
+++ b/reports/deshalbfrei.org.txt
@@ -36,7 +36,7 @@ Advanced Server Mobile Compliance Suite: FAILED
 
 Use compliance suite 'Conversations Compliance Suite' to test deshalbfrei.org
 
-Server is ejabberd 16.09
+Server is ejabberd 17.01
 running XEP-0115: Entity Capabilities…		PASSED
 running XEP-0163: Personal Eventing Protocol…		PASSED
 running Roster Versioning…		PASSED
@@ -49,7 +49,8 @@ running XEP-0352: Client State Indication…		PASSED
 running XEP-0363: HTTP File Upload…		PASSED
 running XEP-0065: SOCKS5 Bytestreams (Proxy)…		PASSED
 running XEP-0357: Push Notifications…		FAILED
-passed 11/12
+running XEP-0368: SRV records for XMPP over TLS…		PASSED
+passed 12/13
 
 Conversations Compliance Suite: FAILED
 

--- a/reports/draugr.de.txt
+++ b/reports/draugr.de.txt
@@ -36,7 +36,7 @@ Advanced Server Mobile Compliance Suite: FAILED
 
 Use compliance suite 'Conversations Compliance Suite' to test draugr.de
 
-Server is ejabberd 16.09
+Server is ejabberd 17.01
 running XEP-0115: Entity Capabilities…		PASSED
 running XEP-0163: Personal Eventing Protocol…		PASSED
 running Roster Versioning…		PASSED
@@ -49,7 +49,8 @@ running XEP-0352: Client State Indication…		PASSED
 running XEP-0363: HTTP File Upload…		PASSED
 running XEP-0065: SOCKS5 Bytestreams (Proxy)…		PASSED
 running XEP-0357: Push Notifications…		FAILED
-passed 11/12
+running XEP-0368: SRV records for XMPP over TLS…		PASSED
+passed 12/13
 
 Conversations Compliance Suite: FAILED
 


### PR DESCRIPTION
Update for draugr.de/deshalbfrei.org as it supports XEP-0368 now