### PR TITLE
Add XEP number to the representation string of RosterVersioning

### DIFF
--- a/src/main/java/eu/siacs/compliance/tests/RosterVersioning.java
+++ b/src/main/java/eu/siacs/compliance/tests/RosterVersioning.java
@@ -16,6 +16,6 @@ public class RosterVersioning extends AbstractStreamFeatureTest {
 
     @Override
     public String getName() {
-        return "Roster Versioning";
+        return "XEP-0237: Roster Versioning";
     }
 }


### PR DESCRIPTION
Every other test has the XEP number in the `getName` method.