### PR TITLE
Update minidns to version 0.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>de.measite.minidns</groupId>
             <artifactId>minidns-hla</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Version 0.2.0 makes ComplianceTester give false negatives on test for XEP-0368 because of NPE thrown on SRV queries.

See: https://github.com/MiniDNS/minidns/issues/64