### PR TITLE
Update compliance test for jabber.systemli.org

### DIFF
--- a/reports/jabber.systemli.org.txt
+++ b/reports/jabber.systemli.org.txt
@@ -49,10 +49,9 @@ running XEP-0363: HTTP File Upload…		PASSED
 running XEP-0065: SOCKS5 Bytestreams (Proxy)…		PASSED
 running XEP-0357: Push Notifications…		PASSED
 running XEP-0368: SRV records for XMPP over TLS…		PASSED
-running XEP-0384: OMEMO Encryption…		FAILED
-running XEP-0313: Message Archive Management (MUC)…		FAILED
-passed 13/15
+running XEP-0384: OMEMO Encryption…		PASSED
+running XEP-0313: Message Archive Management (MUC)…		PASSED
+passed 15/15
 
-Conversations Compliance Suite: FAILED
-
+Conversations Compliance Suite: PASSED
 


### PR DESCRIPTION
* We now support XEP-0384 and XEP-0313, leading to full compliance