### PR TITLE
Another update for libranet.de.txt

### DIFF
--- a/reports/libranet.de.txt
+++ b/reports/libranet.de.txt
@@ -47,12 +47,13 @@ running XEP-0198: Stream Management…		PASSED
 running XEP-0313: Message Archive Management…		PASSED
 running XEP-0352: Client State Indication…		PASSED
 running XEP-0363: HTTP File Upload…		PASSED
-running XEP-0065: SOCKS5 Bytestreams (Proxy)…		FAILED
+running XEP-0065: SOCKS5 Bytestreams (Proxy)…		PASSED
 running XEP-0357: Push Notifications…		PASSED
 running XEP-0368: SRV records for XMPP over TLS…		FAILED
 running XEP-0384: OMEMO Encryption…		PASSED
 running XEP-0313: Message Archive Management (MUC)…		PASSED
-passed 13/15
+passed 14/15
 
 Conversations Compliance Suite: FAILED
+
 


### PR DESCRIPTION
I've added XEP-0065: SOCKS5 Bytestreams support on libranet.de and used the latest version 0.2.3 to run the test.