### PR TITLE
add report about jabber.fsfe.org

### DIFF
--- a/reports/jabber.fsfe.org.txt
+++ b/reports/jabber.fsfe.org.txt
@@ -1,0 +1,57 @@
+Use compliance suite 'Advanced Server Core Compliance Suite' to test jabber.fsfe.org
+
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+passed 2/2
+
+Advanced Server Core Compliance Suite: PASSED
+
+
+Use compliance suite 'Advanced Server IM Compliance Suite' to test jabber.fsfe.org
+
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running Roster Versioning…		PASSED
+running XEP-0280: Message Carbons…		PASSED
+running XEP-0191: Blocking Command…		PASSED
+running XEP-0045: Multi-User Chat…		PASSED
+running XEP-0198: Stream Management…		PASSED
+running XEP-0313: Message Archive Management…		PASSED
+passed 8/8
+
+Advanced Server IM Compliance Suite: PASSED
+
+
+Use compliance suite 'Advanced Server Mobile Compliance Suite' to test jabber.fsfe.org
+
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running XEP-0198: Stream Management…		PASSED
+running XEP-0352: Client State Indication…		PASSED
+running XEP-0357: Push Notifications…		FAILED
+passed 4/5
+
+Advanced Server Mobile Compliance Suite: FAILED
+
+
+Use compliance suite 'Conversations Compliance Suite' to test jabber.fsfe.org
+
+Server is Prosody 0.10.0
+running XEP-0115: Entity Capabilities…		PASSED
+running XEP-0163: Personal Eventing Protocol…		PASSED
+running Roster Versioning…		PASSED
+running XEP-0280: Message Carbons…		PASSED
+running XEP-0191: Blocking Command…		PASSED
+running XEP-0045: Multi-User Chat…		PASSED
+running XEP-0198: Stream Management…		PASSED
+running XEP-0313: Message Archive Management…		PASSED
+running XEP-0352: Client State Indication…		PASSED
+running XEP-0363: HTTP File Upload…		FAILED
+running XEP-0065: SOCKS5 Bytestreams (Proxy)…		PASSED
+running XEP-0357: Push Notifications…		FAILED
+running XEP-0368: SRV records for XMPP over TLS…		FAILED
+running XEP-0384: OMEMO Encryption…		FAILED
+running XEP-0313: Message Archive Management (MUC)…		FAILED
+passed 10/15
+
+Conversations Compliance Suite: FAILED


### PR DESCRIPTION
This is the output of the test with the ComplianceTester tool for jabber.fsfe.org, the Free Software Foundation Europe's Jabber server (which will hopefully be more compliant soon!).